### PR TITLE
Improved NuGet package authoring, Removed debug builds, Bumped to v1.2.2

### DIFF
--- a/NibblePoker.Library.Arguments.Documentation/Doxyfile
+++ b/NibblePoker.Library.Arguments.Documentation/Doxyfile
@@ -6,7 +6,7 @@
 
 DOXYFILE_ENCODING      = UTF-8
 PROJECT_NAME           = "DotNet-Arguments"
-PROJECT_NUMBER         = "1.2.1"
+PROJECT_NUMBER         = "1.2.2"
 PROJECT_BRIEF          = "A simple and 'to-the-point' library to parse launch arguments in .NET and .NET Core applications."
 PROJECT_LOGO           = "./logo.png"
 PROJECT_ICON           = "./favicon.ico"

--- a/NibblePoker.Library.Arguments.sln
+++ b/NibblePoker.Library.Arguments.sln
@@ -10,28 +10,17 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NibblePoker.Library.Argumen
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D60CAED2-85DA-4514-B71D-C7531BFC1B2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D60CAED2-85DA-4514-B71D-C7531BFC1B2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{D60CAED2-85DA-4514-B71D-C7531BFC1B2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{D60CAED2-85DA-4514-B71D-C7531BFC1B2A}.Release|Any CPU.Build.0 = Release|Any CPU
-		{E45E4C87-B8C0-4D4E-B873-207A74B5323E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{E45E4C87-B8C0-4D4E-B873-207A74B5323E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E45E4C87-B8C0-4D4E-B873-207A74B5323E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E45E4C87-B8C0-4D4E-B873-207A74B5323E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{5A473C77-624F-4D07-AFAA-F1FA2CC62FE0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5A473C77-624F-4D07-AFAA-F1FA2CC62FE0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5A473C77-624F-4D07-AFAA-F1FA2CC62FE0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5A473C77-624F-4D07-AFAA-F1FA2CC62FE0}.Release|Any CPU.Build.0 = Release|Any CPU
-		{67F25113-BE46-4FA6-BE24-C88EA1D41C25}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{67F25113-BE46-4FA6-BE24-C88EA1D41C25}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{67F25113-BE46-4FA6-BE24-C88EA1D41C25}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{67F25113-BE46-4FA6-BE24-C88EA1D41C25}.Release|Any CPU.Build.0 = Release|Any CPU
-		{2F3C069C-9D12-411A-BA08-3A536BD072EA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{2F3C069C-9D12-411A-BA08-3A536BD072EA}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2F3C069C-9D12-411A-BA08-3A536BD072EA}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2F3C069C-9D12-411A-BA08-3A536BD072EA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection

--- a/NibblePoker.Library.Arguments/NibblePoker.Library.Arguments.csproj
+++ b/NibblePoker.Library.Arguments/NibblePoker.Library.Arguments.csproj
@@ -12,7 +12,7 @@
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
 
         <!-- https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file -->
-        <PackageId>NibblePoker.Data.Arguments</PackageId>
+        <PackageId>NibblePoker.Library.Arguments</PackageId>
         <PackageVersion>1.2.2</PackageVersion>
         <!--<VersionPrefix></VersionPrefix>-->
         <!--<VersionSuffix></VersionSuffix>-->

--- a/NibblePoker.Library.Arguments/NibblePoker.Library.Arguments.csproj
+++ b/NibblePoker.Library.Arguments/NibblePoker.Library.Arguments.csproj
@@ -1,22 +1,40 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
+        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
-        <PackageVersion>1.2.1</PackageVersion>
-        <Title>NibblePoker Arguments</Title>
+
+        <AssemblyVersion>1.2.2</AssemblyVersion>
+        <FileVersion>1.2.2</FileVersion>
+
         <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+
+        <!-- https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#packing-a-license-expression-or-a-license-file -->
+        <PackageId>NibblePoker.Data.Arguments</PackageId>
+        <PackageVersion>1.2.2</PackageVersion>
+        <!--<VersionPrefix></VersionPrefix>-->
+        <!--<VersionSuffix></VersionSuffix>-->
+        <Authors>NibblePoker,Herwin Bozet</Authors>
+        <Title>NibblePoker Arguments</Title>
         <Description>A simple and 'to-the-point' library to parse launch arguments in .NET and .NET Core applications.</Description>
+        <!--<Copyright></Copyright>-->
+        <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+        <!--<PackageLicenseExpression></PackageLicenseExpression>-->
+        <PackageLicenseFile>LICENSE</PackageLicenseFile>
+        <!--<PackageLicenseUrl></PackageLicenseUrl>-->
         <PackageProjectUrl>https://github.com/aziascreations/DotNet-Arguments</PackageProjectUrl>
-        <PackageLicenseUrl>https://github.com/aziascreations/DotNet-Arguments/blob/master/LICENSE</PackageLicenseUrl>
+        <PackageIcon>icon.png</PackageIcon>
+        <!--<PackageIconUrl></PackageIconUrl>-->
+        <PackageReadmeFile>readme.md</PackageReadmeFile>
+        <PackageTags>argument-parser</PackageTags>
+        <PackageReleaseNotes>Improved NuGet package authoring, Removed debug builds</PackageReleaseNotes>
         <RepositoryUrl>https://github.com/aziascreations/DotNet-Arguments</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <PackageTags>argument-parser</PackageTags>
-        <PackageReleaseNotes>Improved documentation and fixed small copy-paste mistakes</PackageReleaseNotes>
-        <PackageIcon>icon.png</PackageIcon>
-        <AssemblyVersion>1.2.1</AssemblyVersion>
-        <FileVersion>1.2.1</FileVersion>
-        <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+        <RepositoryBranch>master</RepositoryBranch>
+        <!--<RepositoryCommit></RepositoryCommit>-->
+        <!--<PackageType></PackageType>-->
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
@@ -24,16 +42,10 @@
       <DocumentationFile>bin\Release\NibblePoker.Library.Arguments.xml</DocumentationFile>
     </PropertyGroup>
 
-    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-      <DocumentationFile>bin\Debug\NibblePoker.Library.Arguments.xml</DocumentationFile>
-    </PropertyGroup>
-
     <ItemGroup>
-      <None Include="..\icon.png">
-        <Pack>True</Pack>
-        <PackagePath></PackagePath>
-        <Link>icon.png</Link>
-      </None>
+        <None Include="..\icon.png" Pack="true" PackagePath=""/>
+        <None Include="..\LICENSE" Pack="true" PackagePath=""/>
+        <None Include="..\readme.md" Pack="true" PackagePath=""/>
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Doxyfile, NibblePoker.Library.Arguments.sln, and NibblePoker.Library.Arguments.csproj
Fixed the invalid package ID segment this time